### PR TITLE
Initial implementation of hot elements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/lib
+/hot-elements.d.ts
+/hot-elements.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+/tsconfig.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, The Polymer Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "hot-elements",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
+      "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hot-elements",
+  "version": "0.1.0",
+  "description": "An interface for custom element classes to implement hot module reloading",
+  "main": "hot-elements.js",
+  "module": "hot-elements.js",
+  "keywords": [],
+  "author": "The Polymer Authors",
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "@types/node": "^14.0.5",
+    "typescript": "^3.9.3"
+  },
+  "dependencies": {}
+}

--- a/src/hot-elements.ts
+++ b/src/hot-elements.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export {};  // Ensure this file is a module.
+
+const processIsDebug =
+    typeof process === 'undefined' || process.env.NODE_ENV !== 'dev';
+const esmHmrIsPresent = !!(import.meta as HotImportMeta).hot;
+/**
+ * This code shouldn't be imported in prod, but if it is, try to give any
+ * bundler as many chances as it can to dead code eliminate it.
+ */
+const inDebugMode = processIsDebug || esmHmrIsPresent;
+
+/**
+ * Provides an interface by which custom element classes can do hot module
+ * reloading.
+ *
+ * Important warning:
+ *   Hot module reloading is hot in the sense of fast, but also hot as
+ *   in CAUTION WILL VAPORIZE FINGERS. When in doubt, reload the page, and never
+ *   ever use when connected to a production store of data. Any JS based hot
+ *   reloading necessarily violates the assumptions of otherwise-correct code,
+ *   causing it to execute undefined behavior.
+ *
+ * An element class that defines the method notifyOnHotModuleReload can be
+ * defined on the custom elements registry multiple times. The first time,
+ * the element is registered normally. Each subsequent time, the original will
+ * receive a call to notifyOnHotModuleReload with the new class object, where
+ * it can patch prototypes, re-render existing instances, etc.
+ */
+if (inDebugMode) {
+  const isHotReloadableElementClass =
+      (maybe: Constructor<HTMLElement>): maybe is HotReloadableElementClass => {
+        // This isn't safe against name mangling, but this is definitely debug
+        // code, so that's fine.
+        return 'notifyOnHotModuleReload' in maybe;
+      };
+
+  const originalDefine = customElements.define;
+
+  const implMap = new Map<string, HotReloadableElementClass>();
+  const hotDefine: typeof customElements.define = function hotDefine(
+      tagname, classObj) {
+    if (!isHotReloadableElementClass(classObj)) {
+      originalDefine.call(customElements, tagname, classObj);
+      return;
+    }
+    const impl = implMap.get(tagname);
+    if (!impl) {
+      implMap.set(tagname, classObj);
+      originalDefine.call(customElements, tagname, classObj);
+    } else {
+      impl.notifyOnHotModuleReload(tagname, classObj);
+    }
+  };
+
+  customElements.define = hotDefine;
+}
+
+interface Constructor<T> {
+  new(): T;
+}
+
+/**
+ * This is the interface that the custom element class should implement in
+ * order to hot reload.
+ *
+ * Note that this is an interface for the class itself, not instances,so
+ * notifyOnHotModuleReload must be a static method.
+ */
+export interface HotReloadableElementClass extends Constructor<HTMLElement> {
+  /**
+   * Static method that's called when customElements.define has been called
+   * more than once.
+   *
+   * @param tagname The HTML tag name for the class. This is particularly
+   *     useful when notifyOnHotModuleReload is implemented on a base class
+   *     so it might be called with many different tag names. Can be helpful
+   *     in finding instances of the element in the document.
+   * @param updatedClass The newer version of this class
+   *     (or some other class that's trying to claim this class' tagname).
+   */
+  notifyOnHotModuleReload(
+      tagname: string, updatedClass: HotReloadableElementClass): void;
+}
+
+/** See https://github.com/pikapkg/esm-hmr */
+interface HotImportMeta extends ImportMeta {
+  hot?: object;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "target": "esnext",
+    "module": "esnext",
+    "declaration": true,
+    "tsBuildInfoFile": "./",
+    "removeComments": false,
+    "importHelpers": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./",
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
This just provides the interface that overrides customElements.define. My thinking is that the LitElement implementation of `notifyOnHotModuleReload` would live (and be tested) in the lit-element repo, as it needs to access private internals of LitElement.
